### PR TITLE
Fix bower dependency name

### DIFF
--- a/blueprints/ember-cli-swiper/index.js
+++ b/blueprints/ember-cli-swiper/index.js
@@ -5,7 +5,7 @@ module.exports = {
   },
 
   afterInstall() {
-    return this.addBowerPackageToProject('Swiper', '~3.1');
+    return this.addBowerPackageToProject('swiper', '~3.1');
   }
 
 };

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "Swiper": "swiper#^3.3.1"
+    "swiper": "swiper#^3.3.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = {
 
   included(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/Swiper/dist/css/swiper.css');
-    app.import(app.bowerDirectory + '/Swiper/dist/js/swiper.js');
+    app.import(app.bowerDirectory + '/swiper/dist/css/swiper.css');
+    app.import(app.bowerDirectory + '/swiper/dist/js/swiper.js');
   }
 
 };


### PR DESCRIPTION
Currently, doing `ember install ember-cli-swiper` causes an error when installing the bower package because the package is incorrectly set to `Swiper`, but should be `swiper`. The capitalised name is used for the GitHub repo but not for the bower package. You can verify this [here](http://bower.io/search/?q=swiper).