### PR TITLE
Fix fastboot errors

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -100,11 +100,9 @@ export default Ember.Component.extend({
     });
   }),
 
-  initSwiper: Ember.on('init', function() {
-    Ember.run.later(this, () => {
-      this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
-      this.set('registerAs', this);
-    });
+  initSwiper: Ember.on('didInsertElement', function() {
+    this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
+    this.set('registerAs', this);
   })
 
 });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   included(app) {
     this._super.included(app);
     app.import(app.bowerDirectory + '/swiper/dist/css/swiper.css');
-    app.import(app.bowerDirectory + '/swiper/dist/js/swiper.js');
+
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/swiper/dist/js/swiper.js');
+    }
   }
 
 };


### PR DESCRIPTION
Fixed the errors that pop up when you try to run this addon in fastboot. This was the error:

```
navigator is not defined
ReferenceError: navigator is not defined
```

`navigator` is used in swiper.js, so to fix it I've guarded the import in index.js as recommended [here](https://github.com/ember-fastboot/ember-cli-fastboot/issues/104#issuecomment-216411399).

Adding this guard caused an error with the instantiation of the `Swiper` in `swiper-container`. To fix that, I moved it from being in `init` to `didInsertElement` and removed the `Ember.run.later` - I think this will result in the code being executed at about the same time as before? `didInsertElement` [isn't called by fastboot](https://github.com/ember-fastboot/ember-cli-fastboot/issues/104#issuecomment-216411399).

Although these changes mean that the addon can be used in fastboot without causing errors, there's some room for improvement. The HTML representation rendered by fastboot just spits out the full html (all slides) - a more accurate representation might be just the first slide but I'm not familiar enough with swiper.js to cover other potential use cases. I think fixing the errors is a decent first step anyway.

Wasn't sure how to write tests for this either although that seems more like a limitation of fastboot right now.