### PR TITLE
Add support for breakpoints option

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -59,6 +59,10 @@ export default Ember.Component.extend({
     if (this.get('grabCursor')) {
       options.grabCursor = true;
     }
+    
+    if (this.get('breakpoints')) {
+      options.breakpoints = this.get('breakpoints');
+    }
 
     options.onSlideChangeEnd = this.slideChanged.bind(this);
 

--- a/blueprints/ember-cli-swiper/index.js
+++ b/blueprints/ember-cli-swiper/index.js
@@ -5,7 +5,7 @@ module.exports = {
   },
 
   afterInstall() {
-    return this.addBowerPackageToProject('swiper', '~3.1');
+    return this.addBowerPackageToProject('swiper', '~3.3.1 ');
   }
 
 };


### PR DESCRIPTION
Adds support for the `breakpoints` option introduced with Swiper 3.2.0.