### PR TITLE
Upgraded htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "1.0.3"
+    "ember-cli-htmlbars": "1.0.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Our team is using Ember 2.6.1, Ember CLI 2.6.2. Deprecation warnings were appearing for htmlbars 1.0.3.