### PR TITLE
Resolve deprecation by not using didInsertElement

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -116,9 +116,11 @@ export default Ember.Component.extend({
     });
   }),
 
-  initSwiper: Ember.on('didInsertElement', function() {
-    this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
-    this.set('registerAs', this);
-  })
+  initSwiper: function () {
+    Ember.run.schedule('afterRender', this, function () {
+      this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
+      this.set('registerAs', this);
+    });
+  }.on('init')
 
 });


### PR DESCRIPTION
Removed deprecation warning by combining logic from:
+ @abercrave's PR: https://github.com/Suven/ember-cli-swiper/pull/21
+ @furkanayhan's solution: https://github.com/emberjs/ember.js/issues/12290

--------

error was approximately:

`DEPRECATION: A property of <Ember.OutletView:ember1021> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation.`