### PR TITLE
Use ES5 syntax and import js map

### DIFF
--- a/blueprints/ember-cli-swiper/index.js
+++ b/blueprints/ember-cli-swiper/index.js
@@ -1,11 +1,11 @@
+/* jshint node:true */
+
 module.exports = {
-  description: 'add swiper bower package',
+  description: 'Add swiper bower package',
 
-  normalizeEntityName() {
-  },
+  normalizeEntityName: function() {},
 
-  afterInstall() {
-    return this.addBowerPackageToProject('swiper', '~3.3.1 ');
+  afterInstall: function() {
+    return this.addBowerPackageToProject('swiper', '~3.3.1');
   }
-
 };

--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@
 module.exports = {
   name: 'ember-cli-swiper',
 
-  included(app) {
+  included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/swiper/dist/css/swiper.css');
+    app.import(app.bowerDirectory + '/swiper/dist/css/swiper.min.css');
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import(app.bowerDirectory + '/swiper/dist/js/swiper.js');
+      app.import(app.bowerDirectory + '/swiper/dist/js/swiper.min.js');
+      app.import(app.bowerDirectory + '/swiper/dist/js/maps/swiper.min.js.map');
     }
   }
-
 };


### PR DESCRIPTION
Using ES6 in ember-cli based files is not widely supported and causes build failures. I've also added the JS map file to prevent build time warnings.