### PR TITLE
Use swiper.min.js/css instead of swiper.js/css, because only swiper.m…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ module.exports = {
 
   included(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/swiper/dist/css/swiper.css');
+    app.import(app.bowerDirectory + '/swiper/dist/css/swiper.min.css');
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import(app.bowerDirectory + '/swiper/dist/js/swiper.js');
+      app.import(app.bowerDirectory + '/swiper/dist/js/swiper.min.js');
     }
   }
 


### PR DESCRIPTION
…in.js comes with a source map. With swiper.js, there is this warning from Ember:

Warning: ignoring input sourcemap for bower_components/swiper/dist/js/swiper.js because ENOENT: no such file or directory, open '/opt/dev/yilian/mobile-web/tmp/source_map_concat-input_base_path-wEQRgGwm.tmp/0/bower_components/swiper/dist/js/maps/swiper.js.map'