### PR TITLE
Upgrade swiper to 3.4.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "swiper": "swiper#^3.3.1"
+    "swiper": "swiper#^3.4.1"
   }
 }


### PR DESCRIPTION
I'm interested in getting access to some of the more recent changes in swiper since 3.3.1. I looked over their [changelog](https://github.com/nolimits4web/Swiper/blob/master/CHANGELOG.md) and don't see any breaking changes, though I'm not as familiar with the codebase. Your Ember tests pass after upgrading to 3.4.1.