### PR TITLE
adds support for effect attribute

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -10,7 +10,7 @@ export default Component.extend({
   classNames: ['swiper-container'],
   swiper: false,
 
-  swiperOptions: computed('pagination', 'loop', 'vertical', 'onlyExternal', function() {
+  swiperOptions: computed('pagination', 'loop', 'vertical', 'onlyExternal', 'effect', function() {
     let options = {};
 
     if (this.get('pagination')) {
@@ -99,6 +99,23 @@ export default Component.extend({
 
     if (this.get('autoplayDisableOnInteraction')) {
       options.autoplayDisableOnInteraction = this.get('autoplayDisableOnInteraction');
+    }
+
+    // basic support for 'effect' API
+    let effect = this.get('effect');
+    if (effect && effect !== 'slide') {
+      options.effect = this.get('effect');
+
+      // look for effect configurations if an effect other than the default
+      // 'slide' effect is given
+      let effectConfigs = this.getProperties('fade', 'cube', 'overflow', 'flip');
+
+      // add available effect configurations to options
+      Object.keys(effectConfigs).forEach((c) => {
+        if (effectConfigs[c]) {
+          options[c] = effectConfigs[c];
+        }
+      });
     }
 
     options.onSlideChangeEnd = this.slideChanged.bind(this);

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -44,3 +44,9 @@ test('navigation buttons are present if requested', function(assert) {
   assert.ok(this.$('>:first-child').has('.swiper-button-next').length);
   assert.ok(this.$('>:first-child').has('.swiper-button-prev').length);
 });
+
+test('it supports `effect` attribute', function(assert) {
+  this.render(hbs`{{#swiper-container effect='fade'}} Foo {{/swiper-container}}`);
+  assert.ok(this.$().has('.swiper-container-fade').length,
+    'Container has `fade` class');
+});


### PR DESCRIPTION
I have a need to support other effects than the default "slide". 
This PR implements basic support for the `effect` attribute (see [Swiper API](http://idangero.us/swiper/api/) for details) and adds a basic component test to cover this change.