### PR TITLE
More robust addon/engine support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,23 @@ module.exports = {
   name: 'ember-cli-swiper',
 
   included(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
+    
+    var app;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      var current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
+
     app.import(app.bowerDirectory + '/swiper/dist/css/swiper.min.css');
 
     if (!process.env.EMBER_CLI_FASTBOOT) {


### PR DESCRIPTION
This PR properly invokes super (it should be bound) and also uses a more robust method to find `app` (to deal with addons-of-addons situations).

The unbounded super call causes an issue in Ember CLI 2.12.