### PR TITLE
Update swiper-container.js

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -14,7 +14,7 @@ export default Component.extend({
     let options = {};
 
     if (this.get('pagination')) {
-      options.pagination = `#${this.get('elementId')} .swiper-pagination`;
+      options.pagination = `#${this.get('elementId')} > .swiper-pagination`;
       options.paginationClickable = true;
     }
 


### PR DESCRIPTION
Limit the swiper-pagination container to the direct child of the parent.  This allows for nested swiper-containers with pagination, and doesn't overwrite the bullets of the inner pagination containers with the count of the outer container.