### PR TITLE
Adding watchSlidesVisibility options

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -89,6 +89,10 @@ export default Component.extend({
       options.breakpoints = this.get('breakpoints');
     }
 
+    if (this.get('keyboardControl')) {
+      options.keyboardControl = this.get('keyboardControl');
+    }
+
     if (this.get('autoplay')) {
       options.autoplay = this.get('autoplay');
     }

--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -101,6 +101,11 @@ export default Component.extend({
       options.autoplayDisableOnInteraction = this.get('autoplayDisableOnInteraction');
     }
 
+    if (this.get('watchSlidesVisibility')) {
+      options.watchSlidesProgress = true;
+      options.watchSlidesVisibility = true;
+    }
+
     // basic support for 'effect' API
     let effect = this.get('effect');
     if (effect && effect !== 'slide') {

--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -105,8 +105,11 @@ export default Component.extend({
       options.autoplayDisableOnInteraction = this.get('autoplayDisableOnInteraction');
     }
 
-    if (this.get('watchSlidesVisibility')) {
+    if (this.get('watchSlidesProgress')) {
       options.watchSlidesProgress = true;
+    }
+
+    if (this.get('watchSlidesVisibility')) {
       options.watchSlidesVisibility = true;
     }
 


### PR DESCRIPTION
Adding `watchSlidesVisibility` option which adds the css class `.swiper-slide-visible` to visible slides. 

This allows you to hide slides that are not meant to be visible. In my use case I have slides that have box-shadows that get cut off by the slide-container's `overflow: hidden`  

This allow for the css like this.
```scss
 .swiper-slide {
    visibility: hidden;
    &.swiper-slide-visible {
      visibility: visible;
    }
  } 
```

http://idangero.us/swiper/api/#.WN7Wf3TyvdQ