### PR TITLE
call onInit on initialization

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -162,8 +162,8 @@ export default Component.extend({
     run.scheduleOnce('afterRender', this, function() {
       this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
       this.set('registerAs', this);
-      if (this.get('onInit')) {
-        this.sendAction('onInit', this);
+      if (this.get('afterSwiperInit')) {
+        this.sendAction('afterSwiperInit', this);
       }
     });
   })

--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -162,6 +162,9 @@ export default Component.extend({
     run.scheduleOnce('afterRender', this, function() {
       this.set('swiper', new Swiper(`#${this.get('elementId')}`, this.get('swiperOptions')));
       this.set('registerAs', this);
+      if (this.get('onInit')) {
+        this.sendAction('onInit', this);
+      }
     });
   })
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.7.0",
     "ember-suave": "4.0.1",
     "loader.js": "^4.0.10"
   },

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 moduleForComponent('swiper-container', 'Integration | Component | swiper container', {
   integration: true
@@ -49,4 +50,19 @@ test('it supports `effect` attribute', function(assert) {
   this.render(hbs`{{#swiper-container effect='fade'}} Foo {{/swiper-container}}`);
   assert.ok(this.$().has('.swiper-container-fade').length,
     'Container has `fade` class');
+});
+
+test('on initialization, calls `onInit` with the swiper container component if `onInit` is passed in', function(assert) {
+  this.set('actions.onInit', () => {});
+  let spy = sinon.spy(this.get('actions'), 'onInit');
+  this.render(hbs`{{#swiper-container onInit="onInit" registerAs=superDuperSwiper}} Foo {{/swiper-container}}`);
+  assert.equal(spy.callCount, 1);
+  assert.equal(spy.getCall(0).args[0], this.get('superDuperSwiper'));
+});
+
+test('on initialization, does not call `onInit` if `onInit` is not passed in', function(assert) {
+  this.set('actions.onInit', () => {});
+  let spy = sinon.spy(this.get('actions'), 'onInit');
+  this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
+  assert.equal(spy.callCount, 0);
 });

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -52,17 +52,17 @@ test('it supports `effect` attribute', function(assert) {
     'Container has `fade` class');
 });
 
-test('on initialization, calls `onInit` with the swiper container component if `onInit` is passed in', function(assert) {
-  this.set('actions.onInit', () => {});
-  let spy = sinon.spy(this.get('actions'), 'onInit');
-  this.render(hbs`{{#swiper-container onInit="onInit" registerAs=superDuperSwiper}} Foo {{/swiper-container}}`);
+test('on initialization, calls `afterSwiperInit` with the swiper container component if `afterSwiperInit` is passed in', function(assert) {
+  this.set('actions.afterSwiperInit', () => {});
+  let spy = sinon.spy(this.get('actions'), 'afterSwiperInit');
+  this.render(hbs`{{#swiper-container afterSwiperInit="afterSwiperInit" registerAs=superDuperSwiper}} Foo {{/swiper-container}}`);
   assert.equal(spy.callCount, 1);
   assert.equal(spy.getCall(0).args[0], this.get('superDuperSwiper'));
 });
 
-test('on initialization, does not call `onInit` if `onInit` is not passed in', function(assert) {
-  this.set('actions.onInit', () => {});
-  let spy = sinon.spy(this.get('actions'), 'onInit');
+test('on initialization, does not call `afterSwiperInit` if `afterSwiperInit` is not passed in', function(assert) {
+  this.set('actions.afterSwiperInit', () => {});
+  let spy = sinon.spy(this.get('actions'), 'afterSwiperInit');
   this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
   assert.equal(spy.callCount, 0);
 });


### PR DESCRIPTION
This PR adds an explicit `onInit` callback when the swiper is initialized.

Currently, if we want to do something with the actual swiper, we'd have to use the `registerAs` property. As specified in the docs :`{{#swiper-container registerAs=superDuperSwiper}}`.

This is fine, but not really "embery", as it's not data-down actions-up (it's more data-down, data-up). If we want to know when the swiper is done initializing, we'd have to set up an observer on `superDuperSwiper`, which isn't great.

This PR solves this problem. Note I'm keeping `registerAs` property for backwards compatibility.