### PR TITLE
Add support for keyboard and mousewheel options.

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -5,13 +5,28 @@ import layout from '../templates/components/swiper-container';
 
 const { Component, computed, observer, on, run, $ } = Ember;
 
+const swiperParameters = [
+  // Keyboard / Mousewheel
+  'keyboardControl',
+  'mousewheelControl',
+  'mousewheelForceToAxis',
+  'mousewheelInvert',
+  'mousewheelReleaseOnEdges'
+];
+
 export default Component.extend({
   layout,
   classNames: ['swiper-container'],
   swiper: false,
 
-  swiperOptions: computed('pagination', 'loop', 'vertical', 'onlyExternal', 'effect', function() {
+  swiperOptions: computed('pagination', 'loop', 'vertical', 'onlyExternal', 'effect', ...swiperParameters, function() {
     let options = {};
+
+    swiperParameters.forEach((parameter) => {
+      if (this.get(parameter)) {
+        options[parameter] = parameter;
+      }
+    });
 
     if (this.get('pagination')) {
       options.pagination = `#${this.get('elementId')} > .swiper-pagination`;

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -126,6 +126,26 @@
   \{{/swiper-container}}
 </pre>
 
+<h3>Keyboard + Mousewheel Control</h3>
+
+{{#swiper-container keyboardControl=true mousewheelControl=true slidesPerView=2}}
+  {{#swiper-slide}}Slide 1{{/swiper-slide}}
+  {{#swiper-slide}}Slide 2{{/swiper-slide}}
+  {{#swiper-slide}}Slide 3{{/swiper-slide}}
+  {{#swiper-slide}}Slide 4{{/swiper-slide}}
+  {{#swiper-slide}}Slide 5{{/swiper-slide}}
+{{/swiper-container}}
+
+<pre>
+  \{{#swiper-container keyboardControl=true mousewheelControl=true slidesPerView=2}}
+    \{{#swiper-slide}}Slide 1\{{/swiper-slide}}
+    \{{#swiper-slide}}Slide 2\{{/swiper-slide}}
+    \{{#swiper-slide}}Slide 3\{{/swiper-slide}}
+    \{{#swiper-slide}}Slide 4\{{/swiper-slide}}
+    \{{#swiper-slide}}Slide 5\{{/swiper-slide}}
+  \{{/swiper-container}}
+</pre>
+
 <h3>Change Listener</h3>
 
 <p>The configured action receives the HTML-Element of the selected slide.</p>


### PR DESCRIPTION
I made an easy way to add options that are a direct one-to-one mapping. Works great for booleans, but for some reason `mousewheelSensitivity` didn't work. I included only what I confirmed works correctly.

It was actually really easy to support new options. I will definitely add more as I need them! 👍 