### PR TITLE
Adjust pagination parameter to match Swiper API docs

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -29,7 +29,8 @@ export default Component.extend({
     });
 
     if (this.get('pagination')) {
-      options.pagination = `#${this.get('elementId')} > .swiper-pagination`;
+      options.pagination = typeof this.get('pagination') === 'boolean' ?
+        `#${this.get('elementId')} > .swiper-pagination` : this.get('pagination');
       options.paginationClickable = true;
     }
 

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -34,6 +34,9 @@ test('pagination node is present if requested', function(assert) {
 
   this.render(hbs`{{#swiper-container pagination=true}} Foo {{/swiper-container}}`);
   assert.ok(this.$('>:first-child').has('.swiper-pagination').length);
+
+  this.render(hbs`{{#swiper-container pagination=".custom-pagination"}} Foo <div class="custom-pagination"></div>{{/swiper-container}}`);
+  assert.ok(this.$('.custom-pagination').hasClass('swiper-pagination-clickable'));
 });
 
 test('navigation buttons are present if requested', function(assert) {


### PR DESCRIPTION
Adjusts the optional `pagination` parameter to be closer to the [Swiper API docs](http://idangero.us/swiper/api/). E.g. instead of just checking for truthy values, it'll now also accept strings or objects that'll be passed to the Swiper instance.

Amends the integration test to cover this change.