### PR TITLE
enable `simulateTouch` swiper option

### DIFF
--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -59,6 +59,10 @@ export default Component.extend({
       options.followFinger = false;
     }
 
+    if (typeof this.get('simulateTouch') === 'boolean') {
+      options.simulateTouch = this.get('simulateTouch');
+    }
+
     // disable all user interactions
     if (this.get('onlyExternal')) {
       options.onlyExternal = true;


### PR DESCRIPTION
Enables the `simulateTouch` swiper [parameter](http://idangero.us/swiper/api/#parameters), to disable touch-like interactions (swiping through slides).

Did not add any test for this option, as I'm not sure how to test a swipe UI interaction. If there are any non-brittle test solutions, I'm happy to add that.

@Suven I had a use case where I needed to disable dragging of swiper slides. It seems like seeting the [`followFinger`](https://github.com/Suven/ember-cli-swiper/blob/master/addon/components/swiper-container.js#L57) parameter does not have any effects whatsoever, it always resolved to true. Maybe a Swiper bug?