### PR TITLE
Enable all swiper options and replace observers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,28 @@ Make sure you are using a somewhat recent version of nodejs when installing. Eve
 {{/swiper-container}}
 ```
 
-For all supported options see the [demo](http://suven.github.io/ember-cli-swiper/).
+## Options
+
+All [available Swiper options](http://idangero.us/swiper/api) are supported and can be configured two ways:
+
+As top level attributes:
+```handlebars
+{{swiper-container freeMode=true}}
+```
+
+As a hash of options:
+```handlebars
+{{!--
+// In controller
+Controller.extend({
+  myOptions: { parallax: true }
+});
+--}}
+
+{{swiper-container options=myOptions}}
+```
+
+Please note that attribute values will overwrite any conflicting options.
 
 ## Running tests
 

--- a/addon/components/swiper-container.js
+++ b/addon/components/swiper-container.js
@@ -5,6 +5,7 @@ import Component from '@ember/component';
 import { computed, observer } from '@ember/object';
 import { on } from '@ember/object/evented';
 import { run } from '@ember/runloop';
+import { warn } from '@ember/debug';
 import layout from '../templates/components/swiper-container';
 
 const swiperParameters = [
@@ -38,10 +39,20 @@ export default Component.extend({
 
     if (this.get('nextButton')) {
       options.nextButton = this.get('nextButton');
+      warn(
+        'ember-cli-swiper option `nextButton` is ignored while `navigation` active',
+        !this.get('navigation'),
+        { id: 'ember-cli-swiper.next-button-with-navigation' }
+      );
     }
 
     if (this.get('prevButton')) {
       options.prevButton = this.get('prevButton');
+      warn(
+        'ember-cli-swiper option `prevButton` is ignored while `navigation` active',
+        !this.get('navigation'),
+        { id: 'ember-cli-swiper.prev-button-with-navigation' }
+      );
     }
 
     if (this.get('navigation')) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-sinon": "0.7.0",
-    "ember-source": "~2.15.0",
+    "ember-source": "2.15.2",
     "ember-suave": "4.0.1",
     "loader.js": "^4.2.3"
   },

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,10 +1,6 @@
-<p>This is a simple wrapper around <a href="http://idangero.us/swiper/">Swiper</a>
-  by idangerous which itself is a pritty slick, touch-enabled carousel-library.</p>
-
-<p>As this was created out of a particular requirement, only those swiper-options
-  have been ported, which were needed. If you would like to use anything else you
-  see on <a href="http://idangero.us/swiper/demos/">their demos</a>, please create
-  a PullRequest or issue on github.</p>
+<p>
+  A simple wrapper around the touch-enabled carousel-library: <a href="http://idangero.us/swiper/">Swiper</a> by idangerous
+</p>
 
 <h3>Basic usage</h3>
 

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -19,6 +19,42 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim(), 'template block text');
 });
 
+test('it set `noSwiping` via attribute and `options`', function(assert) {
+  let expected = false;
+
+  this.set('noSwiping', expected);
+  this.render(hbs`{{swiper-container noSwiping=noSwiping registerAs=componentInstanceAttr}}`);
+
+  assert.strictEqual(
+    this.get('componentInstanceAttr._swiper.params.noSwiping'),
+    expected,
+    'Swiper instance `noSwiping` configured by `noSwiping` attribute'
+  );
+
+  this.set('options', { noSwiping: expected });
+  this.render(hbs`{{swiper-container options=options registerAs=componentInstanceOpts}}`);
+
+  assert.strictEqual(
+    this.get('componentInstanceOpts._swiper.params.noSwiping'),
+    expected,
+    'Swiper instance `noSwiping` configured by `options.noSwiping`'
+  );
+});
+
+test('it should allow attributes to overwrite `options`', function(assert) {
+  let expected = 'fade';
+
+  this.set('effect', expected);
+  this.set('options', { effect: 'cube' });
+  this.render(hbs`{{swiper-container effect=effect options=options registerAs=componentInstanceAttr}}`);
+
+  assert.strictEqual(
+    this.get('componentInstanceAttr._swiper.params.effect'),
+    expected,
+    'Swiper instance configured by attribute not `options`'
+  );
+});
+
 test('predefined classes are added', function(assert) {
   this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
   assert.ok(this.$('>:first-child').hasClass('swiper-container'));
@@ -64,14 +100,7 @@ test('on initialization, calls `afterSwiperInit` with the swiper container compo
   assert.equal(spy.getCall(0).args[0], this.get('superDuperSwiper'));
 });
 
-test('on initialization, does not call `afterSwiperInit` if `afterSwiperInit` is not passed in', function(assert) {
-  this.set('actions.afterSwiperInit', () => {});
-  let spy = sinon.spy(this.get('actions'), 'afterSwiperInit');
-  this.render(hbs`{{swiper-container}}`);
-  assert.equal(spy.callCount, 0);
-});
-
-test('it destroys the Swiper instance when the component element destroyed', function(assert) {
+test('it destroys the Swiper instance when component element destroyed', function(assert) {
   assert.expect(2);
   this.set('componentInstance', null);
   this.set('active', true);
@@ -80,15 +109,23 @@ test('it destroys the Swiper instance when the component element destroyed', fun
 
   run(() => {
     let componentInstance = this.get('componentInstance');
-    assert.ok(componentInstance.swiper, 'Swiper intantiated');
+    assert.ok(componentInstance._swiper, 'Swiper intantiated');
 
-    sinon.stub(componentInstance.swiper, 'destroy').callsFake(() => {
-      assert.ok(true, 'destroy was called');
-      componentInstance.swiper.destroy.callThrough();
-    });
+    sinon.stub(componentInstance._swiper, 'destroy').callsFake(() =>
+      assert.ok(true, 'destroy was called')).callThrough();
 
     this.set('active', false);
   });
+});
+
+test('it removes all `onSlideChangeEnd` handlers when component element destroyed', function(assert) {
+  this.set('componentInstance', null);
+  this.render(hbs`{{swiper-container registerAs=componentInstance}}`);
+
+  let componentInstance = this.get('componentInstance');
+
+  sinon.stub(componentInstance._swiper, 'off').callsFake((evt) =>
+    assert.strictEqual(evt, 'onSlideChangeEnd')).callThrough();
 });
 
 test('it yields a slide component', function(assert) {

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -25,33 +25,33 @@ test('predefined classes are added', function(assert) {
 });
 
 test('contains the wrapper', function(assert) {
-  this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container}}`);
   assert.ok(this.$('>:first-child').has('.swiper-wrapper').length);
 });
 
 test('pagination node is present if requested', function(assert) {
-  this.render(hbs`{{#swiper-container pagination=false}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container pagination=false}}`);
   assert.notOk(this.$('>:first-child').has('.swiper-pagination').length);
 
-  this.render(hbs`{{#swiper-container pagination=true}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container pagination=true}}`);
   assert.ok(this.$('>:first-child').has('.swiper-pagination').length);
 
-  this.render(hbs`{{#swiper-container pagination=".custom-pagination"}} Foo <div class="custom-pagination"></div>{{/swiper-container}}`);
+  this.render(hbs`{{#swiper-container pagination=".custom-pagination"}}<div class="custom-pagination"></div>{{/swiper-container}}`);
   assert.ok(this.$('.custom-pagination').hasClass('swiper-pagination-clickable'));
 });
 
 test('navigation buttons are present if requested', function(assert) {
-  this.render(hbs`{{#swiper-container navigation=false}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container navigation=false}}`);
   assert.notOk(this.$('>:first-child').has('.swiper-button-next').length);
   assert.notOk(this.$('>:first-child').has('.swiper-button-prev').length);
 
-  this.render(hbs`{{#swiper-container navigation=true}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container navigation=true}}`);
   assert.ok(this.$('>:first-child').has('.swiper-button-next').length);
   assert.ok(this.$('>:first-child').has('.swiper-button-prev').length);
 });
 
 test('it supports `effect` attribute', function(assert) {
-  this.render(hbs`{{#swiper-container effect='fade'}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container effect="fade"}}`);
   assert.ok(this.$().has('.swiper-container-fade').length,
     'Container has `fade` class');
 });
@@ -59,7 +59,7 @@ test('it supports `effect` attribute', function(assert) {
 test('on initialization, calls `afterSwiperInit` with the swiper container component if `afterSwiperInit` is passed in', function(assert) {
   this.set('actions.afterSwiperInit', () => {});
   let spy = sinon.spy(this.get('actions'), 'afterSwiperInit');
-  this.render(hbs`{{#swiper-container afterSwiperInit="afterSwiperInit" registerAs=superDuperSwiper}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container afterSwiperInit="afterSwiperInit" registerAs=superDuperSwiper}}`);
   assert.equal(spy.callCount, 1);
   assert.equal(spy.getCall(0).args[0], this.get('superDuperSwiper'));
 });
@@ -67,7 +67,7 @@ test('on initialization, calls `afterSwiperInit` with the swiper container compo
 test('on initialization, does not call `afterSwiperInit` if `afterSwiperInit` is not passed in', function(assert) {
   this.set('actions.afterSwiperInit', () => {});
   let spy = sinon.spy(this.get('actions'), 'afterSwiperInit');
-  this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container}}`);
   assert.equal(spy.callCount, 0);
 });
 

--- a/tests/integration/components/swiper-container-test.js
+++ b/tests/integration/components/swiper-container-test.js
@@ -56,7 +56,7 @@ test('it should allow attributes to overwrite `options`', function(assert) {
 });
 
 test('predefined classes are added', function(assert) {
-  this.render(hbs`{{#swiper-container}} Foo {{/swiper-container}}`);
+  this.render(hbs`{{swiper-container}}`);
   assert.ok(this.$('>:first-child').hasClass('swiper-container'));
 });
 
@@ -119,6 +119,7 @@ test('it destroys the Swiper instance when component element destroyed', functio
 });
 
 test('it removes all `onSlideChangeEnd` handlers when component element destroyed', function(assert) {
+  assert.expect(1);
   this.set('componentInstance', null);
   this.render(hbs`{{swiper-container registerAs=componentInstance}}`);
 
@@ -131,4 +132,49 @@ test('it removes all `onSlideChangeEnd` handlers when component element destroye
 test('it yields a slide component', function(assert) {
   this.render(hbs`{{#swiper-container as |container|}}{{container.slide}}{{/swiper-container}}`);
   assert.equal(this.$('.swiper-slide').length, 1, 'renders a single slide');
+});
+
+test('it activates the slide at index `currentSlide` on render', function(assert) {
+  this.render(hbs`
+    {{#swiper-container currentSlide=1}}
+      {{swiper-slide}}
+      {{swiper-slide}}
+    {{/swiper-container}}`);
+
+  assert.ok(
+    this.$('.swiper-slide').last().hasClass('swiper-slide-active'),
+    'set slide at index 1 to active'
+  );
+});
+
+test('it updates the active slide when `currentSlide` is updated', function(assert) {
+  this.set('currentSlide', 0);
+
+  this.render(hbs`
+    {{#swiper-container currentSlide=currentSlide}}
+      {{swiper-slide}}
+      {{swiper-slide}}
+    {{/swiper-container}}`);
+
+  this.set('currentSlide', 1);
+
+  assert.ok(
+    this.$('.swiper-slide').last().hasClass('swiper-slide-active'),
+    'set slide at index 1 to active'
+  );
+});
+
+test('it triggers `swiper.update()` when `updateFor` is updated', function(assert) {
+  assert.expect(1);
+
+  this.set('updateFor', '');
+  this.render(hbs`
+    {{swiper-container updateFor=updateFor registerAs=componentInstance}}`);
+
+  let componentInstance = this.get('componentInstance');
+
+  sinon.stub(componentInstance._swiper, 'update').callsFake(() =>
+    assert.ok(true, 'called swiper.update')).callThrough();
+
+  this.set('updateFor', 'updateTranslate');
 });

--- a/tests/integration/components/swiper-slide-test.js
+++ b/tests/integration/components/swiper-slide-test.js
@@ -18,15 +18,15 @@ test('it renders', function(assert) {
 });
 
 test('predefined classes are added', function(assert) {
-  this.render(hbs`{{#swiper-slide}} Foo {{/swiper-slide}}`);
+  this.render(hbs`{{swiper-slide}}`);
   assert.ok(this.$('>:first-child').hasClass('swiper-slide'));
 
-  this.render(hbs`{{#swiper-slide class='foo bar'}} Foo {{/swiper-slide}}`);
+  this.render(hbs`{{swiper-slide class='foo bar'}}`);
   assert.ok(this.$('>:first-child').hasClass('swiper-slide'));
 });
 
 test('own classes are added', function(assert) {
-  this.render(hbs`{{#swiper-slide class='foo bar'}} Foo {{/swiper-slide}}`);
+  this.render(hbs`{{swiper-slide class='foo bar'}}`);
   assert.ok(this.$('>:first-child').hasClass('foo'));
   assert.ok(this.$('>:first-child').hasClass('bar'));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,9 +2510,9 @@ ember-sinon@0.7.0:
     ember-cli-babel "^5.1.7"
     sinon "^2.1.0"
 
-ember-source@~2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.15.0.tgz#901cbe3abee09292372b06f6aa8dd342683be2d5"
+ember-source@2.15.2:
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.15.2.tgz#544c7bcee7b50532e4a10c5572ddf42c835abc93"
   dependencies:
     "@glimmer/compiler" "^0.25.3"
     "@glimmer/node" "^0.25.3"


### PR DESCRIPTION
Passes all component attributes as configuration options to Swiper and replaces usage of observers with component lifecycle hooks.

This PR is an exclusive alternative for #32.
This PR closes issues: #72, #53, #51, #10.

Looking for feedback and review from the community before getting this merged.