### PR TITLE
Invalid API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you are using a somewhat recent version of nodejs when installing. Eve
 
 ## Options
 
-All [available Swiper options](http://idangero.us/swiper/api) are supported and can be configured two ways:
+All [available Swiper options](https://github.com/nolimits4web/Swiper/blob/Swiper3/API.md) are supported and can be configured two ways:
 
 As top level attributes:
 ```handlebars


### PR DESCRIPTION
The current version of ember-cli-swiper uses Swiper ^3.4.2. But there is a new version 4, which has a different API documentation. Updated the link in readme to point to v3 API.